### PR TITLE
Fix reference to a non-existing tag in halo2curves

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = 'v0.2.0' }
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', rev = 'bbd4cee10dbf9c51e0456ea67ec2b894b49f688c' }
 group = "0.12.0"
 subtle = { version = "2.3", default-features = false }
 


### PR DESCRIPTION
Halo2curves has removed the tag v0.2.0 from the repo. It broke all builds which were depending on this package. This commit specifies the concrete revision the removed tag was pointing at to keep the builds working.